### PR TITLE
Feat/ref time import

### DIFF
--- a/src/main/python/importer/import_window.py
+++ b/src/main/python/importer/import_window.py
@@ -18,17 +18,22 @@ class ImportWindow(QDialog):
 
     PREVIEW_ITEM_COUNT = 10
 
-    def __init__(self, target_table_model: Model, parent: QWidget | None = ..., f: Qt.WindowType = ...) -> None:
+    def __init__(
+        self,
+        target_table_model: Model,
+        parent: QWidget | None = ...,
+        f: Qt.WindowType = ...,
+    ) -> None:
         super().__init__(parent, f)
         self.ui = Ui_ImportWindow()
         self.ui.setupUi(self)
         self.setWindowModality(Qt.WindowModality.ApplicationModal)
         self.ui.fileFormatGroup.setEnabled(False)
-        self.ui.configurationGroup.setEnabled(False)
-        self.ui.parametersDefinitionGroup.setEnabled(False)
-        self.ui.dataEnhancementGroup.setEnabled(False)
+        self.ui.configurationGroup.setVisible(False)
+        self.ui.parametersDefinitionGroup.setVisible(False)
+        self.ui.dataEnhancementGroup.setVisible(False)
 
-        self.ui.setStartTimeAsOriginCheckBox.setVisible(False)
+        # self.ui.setStartTimeAsOriginCheckBox.setVisible(True)
 
         self._target_table_model = target_table_model._mainTableModel
         self._file_path = ""
@@ -55,23 +60,31 @@ class ImportWindow(QDialog):
         self.ui.tabulationRadioButton.toggled.connect(self.tabulation_toggled)
         self.ui.semiclonRadioButton.toggled.connect(self.semicolon_toggled)
         self.ui.spaceRadioButton.toggled.connect(self.space_toggled)
-        self.ui.ligneIgnoreSpinBox.valueChanged.connect(
-            self.ligne_ignore_changed)
+        self.ui.ligneIgnoreSpinBox.valueChanged.connect(self.ligne_ignore_changed)
         self.ui.importButton.clicked.connect(self.finish_import)
         self.ui.closeButton.clicked.connect(self.close)
         self.ui.columnFirstLineCheckBox.stateChanged.connect(
-            lambda x: self._opening_function())
-        self.ui.supplementaryParamscheckBox.stateChanged.connect(self.update_preview_gpx)
-        self.ui.interpolationCheckBox.stateChanged.connect(self.interpolation_toggled)
-        
-        self.TIME_FORMATS = {0:"seconds",1:"hh:mm:ss"}
+            lambda x: self._opening_function()
+        )
+        self.ui.supplementaryParamscheckBox.stateChanged.connect(
+            self.update_preview_gpx
+        )
+        self.ui.interpolationCheckBox.stateChanged.connect(self.update_preview_gpx)
+        self.ui.setStartTimeAsOriginCheckBox.stateChanged.connect(
+            self.update_preview_gpx
+        )
+
+        self.TIME_FORMATS = {0: "seconds", 1: "hh:mm:ss"}
         self._time_format_model = QStandardItemModel(self)
-        self._time_format_model.appendColumn([QStandardItem(i) for i in self.TIME_FORMATS.values()])
+        self._time_format_model.appendColumn(
+            [QStandardItem(i) for i in self.TIME_FORMATS.values()]
+        )
         self.ui.timeFormatComboBox.setModel(self._time_format_model)
 
     def choose_file(self):
         file_path, _ = QFileDialog.getOpenFileName(
-            self, 'Import file', '', 'All files (*.*)')
+            self, "Import file", "", "All files (*.*)"
+        )
         if file_path:
             self.ui.fileLineEdit.setText(file_path)
             self.ui.fileFormatGroup.setEnabled(True)
@@ -85,7 +98,8 @@ class ImportWindow(QDialog):
         else:
             self.ui.fileLineEdit.setText(self._file_path)
             _ = QMessageBox.critical(
-                self, "Invalid File", "Selected file does not exist")
+                self, "Invalid File", "Selected file does not exist"
+            )
 
     def open_file(self, file_path: str):
         self._file_path = file_path
@@ -108,18 +122,18 @@ class ImportWindow(QDialog):
             self.ui.GPXRadioButton.setChecked(False)
             self._opening_function = self.update_preview_csv
             self.update_preview_csv()
-            self.ui.configurationGroup.setEnabled(True)
-            self.ui.parametersDefinitionGroup.setEnabled(True)
-            self.ui.dataEnhancementGroup.setEnabled(False)
+            self.ui.configurationGroup.setVisible(True)
+            self.ui.parametersDefinitionGroup.setVisible(True)
+            self.ui.dataEnhancementGroup.setVisible(False)
 
     def gpx_toggled(self):
         if self.ui.GPXRadioButton.isChecked():
             self.ui.CSVRadioButton.setChecked(False)
             self._opening_function = self.update_preview_gpx
             self.update_preview_gpx()
-            self.ui.configurationGroup.setEnabled(False)
-            self.ui.parametersDefinitionGroup.setEnabled(False)
-            self.ui.dataEnhancementGroup.setEnabled(True)
+            self.ui.configurationGroup.setVisible(False)
+            self.ui.parametersDefinitionGroup.setVisible(False)
+            self.ui.dataEnhancementGroup.setVisible(True)
 
     def comma_toggled(self):
         if self.ui.commaRadioButton.isChecked():
@@ -154,7 +168,6 @@ class ImportWindow(QDialog):
             self._opening_function()
 
     def interpolation_toggled(self):
-        self.ui.setStartTimeAsOriginCheckBox.setVisible(self.ui.interpolationCheckBox.isChecked())
         self.update_preview_gpx()
 
     def ligne_ignore_changed(self):
@@ -165,20 +178,36 @@ class ImportWindow(QDialog):
         self.update_parameters_fieldname_choices()
 
     def update_preview_gpx(self):
+        self.ui.supplementaryParamscheckBox.setEnabled(
+            not self.ui.interpolationCheckBox.isChecked()
+        )
+        self.ui.interpolationCheckBox.setEnabled(
+            not self.ui.supplementaryParamscheckBox.isChecked()
+        )
+
         self._tableModel.clear()
         if self.ui.interpolationCheckBox.isChecked():
-            #TODO : To be implemented
-            pass
+            import_gpx_file_module(
+                self._tableModel,
+                self._file_path,
+                self.PREVIEW_ITEM_COUNT,
+                self.ui.setStartTimeAsOriginCheckBox.isChecked(),
+            )
         else:
-            gpx_datas = gpx_read(self._file_path)
-        import_gpx_file(self._tableModel, self._file_path, limit=self.PREVIEW_ITEM_COUNT,
-                        with_supp_data=self.ui.supplementaryParamscheckBox.isChecked(),
-                        ref_time_used=self.ui.setStartTimeAsOriginCheckBox.isChecked())
+            import_gpx_file(
+                self._tableModel,
+                self._file_path,
+                self.PREVIEW_ITEM_COUNT,
+                with_supp_data=self.ui.supplementaryParamscheckBox.isChecked(),
+                ref_time_used=self.ui.setStartTimeAsOriginCheckBox.isChecked(),
+            )
 
     def update_parameters_fieldname_choices(self):
         self._parameters_fieldname_choices.clear()
-        headers = [self._tableModel.horizontalHeaderItem(
-            i) for i in range(self._tableModel.columnCount())]
+        headers = [
+            self._tableModel.horizontalHeaderItem(i)
+            for i in range(self._tableModel.columnCount())
+        ]
         self._parameters_fieldname_choices.appendColumn(headers)
 
     def csv_to_model(self, model: QStandardItemModel, nbr_line: int = -1):
@@ -187,7 +216,7 @@ class ImportWindow(QDialog):
         converters = {}
 
         try:
-            with open(self._file_path, 'r', newline='') as csvfile:
+            with open(self._file_path, "r", newline="") as csvfile:
                 reader = csv.reader(csvfile, delimiter=self._delimiter)
 
                 # First line
@@ -197,10 +226,23 @@ class ImportWindow(QDialog):
                     return  # Empty file
 
                 if self.ui.timeFormatComboBox.currentIndex() == 1:
-                    converters = {self.ui.timeComboBox.currentText(): lambda t: datetime.strptime(t, "%H:%M:%S").hour*3600 + datetime.strptime(t, "%H:%M:%S").minute*60 + datetime.strptime(t, "%H:%M:%S").second,
-                                  self.ui.bankComboBox.currentText(): lambda deg: -float(deg) * math.pi / 180,
-                                  self.ui.pitchComboBox.currentText(): lambda deg: -float(deg) * math.pi / 180,
-                                  self.ui.headingComboBox.currentText():lambda deg: float(deg) * math.pi / 180}
+                    converters = {
+                        self.ui.timeComboBox.currentText(): lambda t: datetime.strptime(
+                            t, "%H:%M:%S"
+                        ).hour
+                        * 3600
+                        + datetime.strptime(t, "%H:%M:%S").minute * 60
+                        + datetime.strptime(t, "%H:%M:%S").second,
+                        self.ui.bankComboBox.currentText(): lambda deg: -float(deg)
+                        * math.pi
+                        / 180,
+                        self.ui.pitchComboBox.currentText(): lambda deg: -float(deg)
+                        * math.pi
+                        / 180,
+                        self.ui.headingComboBox.currentText(): lambda deg: float(deg)
+                        * math.pi
+                        / 180,
+                    }
                 # Header handling
                 if not self.ui.columnFirstLineCheckBox.isChecked():
                     model.appendRow([QStandardItem(field) for field in headers])
@@ -230,7 +272,7 @@ class ImportWindow(QDialog):
                         except Exception as e:
                             print(row[col_idx])
                             print(type(row[col_idx]))
-                            raise Exception # TODO To improve with custom exception or handling
+                            raise Exception  # TODO To improve with custom exception or handling
 
                     model.appendRow([QStandardItem(str(field)) for field in row])
 
@@ -241,30 +283,49 @@ class ImportWindow(QDialog):
         except FileNotFoundError:
             print(f"Fichier introuvable : {self._file_path}")
 
-
     def finish_import(self):
         # Checks of compatibility of the main parameters shall be performed before any import
         if self.ui.CSVRadioButton.isChecked():
             self._target_table_model.clear()
             self.csv_to_model(self._target_table_model)
             self._target_table_model.setHorizontalHeaderItem(
-                self.ui.timeComboBox.currentIndex(), QStandardItem("ZULU TIME"))
+                self.ui.timeComboBox.currentIndex(), QStandardItem("ZULU TIME")
+            )
             self._target_table_model.setHorizontalHeaderItem(
-                self.ui.longitudeComboBox.currentIndex(), QStandardItem("Plane Longitude"))
+                self.ui.longitudeComboBox.currentIndex(),
+                QStandardItem("Plane Longitude"),
+            )
             self._target_table_model.setHorizontalHeaderItem(
-                self.ui.latitudeComboBox.currentIndex(), QStandardItem("Plane Latitude"))
+                self.ui.latitudeComboBox.currentIndex(), QStandardItem("Plane Latitude")
+            )
             self._target_table_model.setHorizontalHeaderItem(
-                self.ui.altitudeComboBox.currentIndex(), QStandardItem("Plane Altitude"))
+                self.ui.altitudeComboBox.currentIndex(), QStandardItem("Plane Altitude")
+            )
             if (a := self.ui.bankComboBox.currentIndex()) >= 0:
-                self._target_table_model.setHorizontalHeaderItem(a, QStandardItem("Plane Bank Degrees"))
+                self._target_table_model.setHorizontalHeaderItem(
+                    a, QStandardItem("Plane Bank Degrees")
+                )
             if (a := self.ui.pitchComboBox.currentIndex()) >= 0:
-                self._target_table_model.setHorizontalHeaderItem(a, QStandardItem("Plane Pitch Degrees"))
+                self._target_table_model.setHorizontalHeaderItem(
+                    a, QStandardItem("Plane Pitch Degrees")
+                )
             if (a := self.ui.headingComboBox.currentIndex()) >= 0:
-                self._target_table_model.setHorizontalHeaderItem(a, QStandardItem("Plane Heading Degrees True"))
+                self._target_table_model.setHorizontalHeaderItem(
+                    a, QStandardItem("Plane Heading Degrees True")
+                )
         elif self.ui.GPXRadioButton.isChecked():
             self._target_table_model.clear()
             if self.ui.interpolationCheckBox.isChecked():
-                import_gpx_file_module(self._target_table_model, self._file_path, self.ui.setStartTimeAsOriginCheckBox.isChecked())
+                import_gpx_file_module(
+                    self._target_table_model,
+                    self._file_path,
+                    ref_time_used=self.ui.setStartTimeAsOriginCheckBox.isChecked(),
+                )
             else:
-                import_gpx_file(self._target_table_model, self._file_path, with_supp_data=self.ui.supplementaryParamscheckBox.isChecked())
+                import_gpx_file(
+                    self._target_table_model,
+                    self._file_path,
+                    with_supp_data=self.ui.supplementaryParamscheckBox.isChecked(),
+                    ref_time_used=self.ui.setStartTimeAsOriginCheckBox.isChecked(),
+                )
         self.close()

--- a/src/main/python/importer/import_window.py
+++ b/src/main/python/importer/import_window.py
@@ -28,6 +28,8 @@ class ImportWindow(QDialog):
         self.ui.parametersDefinitionGroup.setEnabled(False)
         self.ui.dataEnhancementGroup.setEnabled(False)
 
+        self.ui.setStartTimeAsOriginCheckBox.setVisible(False)
+
         self._target_table_model = target_table_model._mainTableModel
         self._file_path = ""
         self._delimiter = ","
@@ -60,6 +62,7 @@ class ImportWindow(QDialog):
         self.ui.columnFirstLineCheckBox.stateChanged.connect(
             lambda x: self._opening_function())
         self.ui.supplementaryParamscheckBox.stateChanged.connect(self.update_preview_gpx)
+        self.ui.interpolationCheckBox.stateChanged.connect(self.interpolation_toggled)
         
         self.TIME_FORMATS = {0:"seconds",1:"hh:mm:ss"}
         self._time_format_model = QStandardItemModel(self)
@@ -107,7 +110,7 @@ class ImportWindow(QDialog):
             self.update_preview_csv()
             self.ui.configurationGroup.setEnabled(True)
             self.ui.parametersDefinitionGroup.setEnabled(True)
-            self.ui.dataEnhancementGroup.setEnabled(True)
+            self.ui.dataEnhancementGroup.setEnabled(False)
 
     def gpx_toggled(self):
         if self.ui.GPXRadioButton.isChecked():
@@ -150,6 +153,10 @@ class ImportWindow(QDialog):
             self._delimiter = "\t"
             self._opening_function()
 
+    def interpolation_toggled(self):
+        self.ui.setStartTimeAsOriginCheckBox.setVisible(self.ui.interpolationCheckBox.isChecked())
+        self.update_preview_gpx()
+
     def ligne_ignore_changed(self):
         self._opening_function()
 
@@ -164,7 +171,9 @@ class ImportWindow(QDialog):
             pass
         else:
             gpx_datas = gpx_read(self._file_path)
-        import_gpx_file(self._tableModel, self._file_path, limit=self.PREVIEW_ITEM_COUNT, with_supp_data=self.ui.supplementaryParamscheckBox.isChecked())
+        import_gpx_file(self._tableModel, self._file_path, limit=self.PREVIEW_ITEM_COUNT,
+                        with_supp_data=self.ui.supplementaryParamscheckBox.isChecked(),
+                        ref_time_used=self.ui.setStartTimeAsOriginCheckBox.isChecked())
 
     def update_parameters_fieldname_choices(self):
         self._parameters_fieldname_choices.clear()
@@ -255,7 +264,7 @@ class ImportWindow(QDialog):
         elif self.ui.GPXRadioButton.isChecked():
             self._target_table_model.clear()
             if self.ui.interpolationCheckBox.isChecked():
-                import_gpx_file_module(self._target_table_model, self._file_path)
+                import_gpx_file_module(self._target_table_model, self._file_path, self.ui.setStartTimeAsOriginCheckBox.isChecked())
             else:
                 import_gpx_file(self._target_table_model, self._file_path, with_supp_data=self.ui.supplementaryParamscheckBox.isChecked())
         self.close()

--- a/src/main/python/importer/import_window.py
+++ b/src/main/python/importer/import_window.py
@@ -33,7 +33,8 @@ class ImportWindow(QDialog):
         self.ui.parametersDefinitionGroup.setVisible(False)
         self.ui.dataEnhancementGroup.setVisible(False)
 
-        # self.ui.setStartTimeAsOriginCheckBox.setVisible(True)
+        self.ui.interpLengthLabel.setEnabled(False)
+        self.ui.interpDoubleSpinBox.setEnabled(False)
 
         self._target_table_model = target_table_model._mainTableModel
         self._file_path = ""
@@ -73,6 +74,7 @@ class ImportWindow(QDialog):
         self.ui.setStartTimeAsOriginCheckBox.stateChanged.connect(
             self.update_preview_gpx
         )
+        self.ui.interpDoubleSpinBox.valueChanged.connect(self.update_preview_gpx)
 
         self.TIME_FORMATS = {0: "seconds", 1: "hh:mm:ss"}
         self._time_format_model = QStandardItemModel(self)
@@ -187,13 +189,18 @@ class ImportWindow(QDialog):
 
         self._tableModel.clear()
         if self.ui.interpolationCheckBox.isChecked():
+            self.ui.interpLengthLabel.setEnabled(True)
+            self.ui.interpDoubleSpinBox.setEnabled(True)
             import_gpx_file_module(
                 self._tableModel,
                 self._file_path,
                 self.PREVIEW_ITEM_COUNT,
-                self.ui.setStartTimeAsOriginCheckBox.isChecked(),
+                ref_time_used=self.ui.setStartTimeAsOriginCheckBox.isChecked(),
+                interp_length=self.ui.interpDoubleSpinBox.value(),
             )
         else:
+            self.ui.interpLengthLabel.setEnabled(False)
+            self.ui.interpDoubleSpinBox.setEnabled(False)
             import_gpx_file(
                 self._tableModel,
                 self._file_path,
@@ -320,6 +327,7 @@ class ImportWindow(QDialog):
                     self._target_table_model,
                     self._file_path,
                     ref_time_used=self.ui.setStartTimeAsOriginCheckBox.isChecked(),
+                    interp_length=self.ui.interpDoubleSpinBox.value(),
                 )
             else:
                 import_gpx_file(

--- a/src/main/python/importer/importer.py
+++ b/src/main/python/importer/importer.py
@@ -13,15 +13,15 @@ from src.main.python.tools.gpx_interpolate import GPXData, gpx_interpolate, gpx_
 M_TO_FT = 1/0.3048
 
 
-def import_gpx_file(tableModel: QStandardItemModel, fileName, limit=math.inf, ref_time_used=False, with_supp_data=False):
+def import_gpx_file(tableModel: QStandardItemModel, fileName, limit=math.inf, with_supp_data=False, ref_time_used=False):
     """Updates the table with the trajectory found in a given .gpx file
 
     Args:
         tableModel (QStandardItemModel): the table that displays the trajectory 
         fileName (String): the file name of the imported .gpx file
         limit (int): an optional limit of imported rows
-        ref_time_used (Boolean): whether the first time point is used as reference
         with_supp_data (bool): if supplementary data are retrieved from description tag
+        ref_time_used (Boolean): whether the first time point is used as reference
 
     Returns:
         Any: null
@@ -81,13 +81,14 @@ def import_gpx_file(tableModel: QStandardItemModel, fileName, limit=math.inf, re
                     len(headers) + i, Qt.Orientation.Horizontal, header)
         # Set time label initial value
 
-def import_gpx_file_module(tableModel: QStandardItemModel, fileName, ref_time_used=False):
+def import_gpx_file_module(tableModel: QStandardItemModel, fileName, limit=math.inf, ref_time_used=False):
     """Updates the table with the trajectory found in a given .gpx file with interpolation
     computed globally by module
 
     Args:
         tableModel (QStandardItemModel): the table that displays the trajectory 
         fileName (String): the file name of the imported .gpx file
+        limit (int): an optional limit of imported rows
         ref_time_used (Boolean): whether the first time point is used as reference
 
     Returns:
@@ -100,7 +101,7 @@ def import_gpx_file_module(tableModel: QStandardItemModel, fileName, ref_time_us
     ref_tstamp = first_interp_point_time.time if ref_time_used else 0.0
     previous_interp_point = first_interp_point_time
     previous_attitude = Attitude(0, 0, 0)
-    for j in range(1, len(gpx_datas['lat'])):
+    for j in range(1, min(len(gpx_datas['lat']), limit)):
         interp_point = GPXTrackPoint(
             gpx_datas['lat'][j], gpx_datas['lon'][j], gpx_datas['ele'][j], gpx_datas['tstamp'][j])
         attitude = compute_attitude_from_gpx(

--- a/src/main/python/importer/importer.py
+++ b/src/main/python/importer/importer.py
@@ -9,18 +9,18 @@ from src.main.python.importer.specific_parsers import SpecificParser
 from src.main.python.datas.datas_manager import FlightDatasManager
 from src.main.python.flight_model.flight_model import Attitude, compute_attitude_from_gpx
 from src.main.python.tools.gpx_interpolate import GPXData, gpx_interpolate, gpx_read
-from src.main.python.tools.geometry import DEG_2_RAD
 
 M_TO_FT = 1/0.3048
 
 
-def import_gpx_file(tableModel: QStandardItemModel, fileName, limit=math.inf, with_supp_data=False):
+def import_gpx_file(tableModel: QStandardItemModel, fileName, limit=math.inf, ref_time_used=False, with_supp_data=False):
     """Updates the table with the trajectory found in a given .gpx file
 
     Args:
         tableModel (QStandardItemModel): the table that displays the trajectory 
         fileName (String): the file name of the imported .gpx file
         limit (int): an optional limit of imported rows
+        ref_time_used (Boolean): whether the first time point is used as reference
         with_supp_data (bool): if supplementary data are retrieved from description tag
 
     Returns:
@@ -44,7 +44,7 @@ def import_gpx_file(tableModel: QStandardItemModel, fileName, limit=math.inf, wi
                         attitude = Attitude(0, 0, 0)
                         row = [
                             QStandardItem(
-                                str(previous_point.time_difference(first_point))),
+                                str(previous_point.time_difference(first_point) if ref_time_used else previous_point.time.timestamp())),
                             QStandardItem(str(previous_point.latitude)),
                             QStandardItem(str(previous_point.longitude)),
                             QStandardItem(str(previous_point.elevation)),
@@ -81,73 +81,14 @@ def import_gpx_file(tableModel: QStandardItemModel, fileName, limit=math.inf, wi
                     len(headers) + i, Qt.Orientation.Horizontal, header)
         # Set time label initial value
 
-
-def import_gpx_file_interp(tableModel: QStandardItemModel, fileName):
-    """Updates the table with the trajectory found in a given .gpx file with interpolation
-    computed individually between points
-
-    Args:
-        tableModel (QStandardItemModel): the table that displays the trajectory 
-        fileName (String): the file name of the imported .gpx file
-
-    Returns:
-        Any: null
-    """
-    with open(fileName, 'r') as gpxfile:
-        reader_gpx = gpxpy.parse(gpxfile)
-        headers = FlightDatasManager.get_current_keys()
-        first_point = reader_gpx.tracks[0].segments[0].points[0]
-        previous_point = first_point
-        for track in reader_gpx.tracks:
-            for segment in track.segments:
-                for i, point in enumerate(segment.points):
-                    if i > 0:
-                        gpx_data = {'lat': [previous_point.latitude, point.latitude],
-                                    'lon': [previous_point.longitude, point.longitude],
-                                    'ele': [previous_point.elevation, point.elevation],
-                                    'tstamp': [previous_point.time_difference(first_point), point.time_difference(first_point)],
-                                    'tzinfo': []
-                                    }
-                        interp_data = gpx_interpolate(gpx_data, 1, 10)
-                        previous_interp_point = GPXTrackPoint(
-                            interp_data['lat'][0], interp_data['lon'][0], interp_data['ele'][0], interp_data['tstamp'][0])
-                        previous_attitude = Attitude(0, 0, 0)
-                        for j in range(1, len(interp_data['lat'])):
-
-                            interp_point = GPXTrackPoint(
-                                interp_data['lat'][j], interp_data['lon'][j], interp_data['ele'][j], interp_data['tstamp'][j])
-                            attitude = compute_attitude_from_gpx(
-                                previous_attitude, previous_interp_point, interp_point)
-                            row = [
-                                QStandardItem(str(previous_interp_point.time)),
-                                  QStandardItem(
-                                    str(previous_interp_point.latitude)),
-                                QStandardItem(
-                                    str(previous_interp_point.longitude)),
-                                QStandardItem(
-                                    str(previous_interp_point.elevation)),
-                                QStandardItem(str(attitude.phi)),
-                                QStandardItem(str(attitude.theta)),
-                                QStandardItem(str(attitude.psi))
-                            ]
-                            tableModel.appendRow(row)
-                            previous_interp_point = interp_point
-                            previous_attitude = attitude
-                    previous_point = point
-
-        for i, header in enumerate(headers):
-            tableModel.setHeaderData(
-                i, Qt.Orientation.Horizontal, header)
-        # Set time label initial value
-
-
-def import_gpx_file_module(tableModel: QStandardItemModel, fileName):
+def import_gpx_file_module(tableModel: QStandardItemModel, fileName, ref_time_used=False):
     """Updates the table with the trajectory found in a given .gpx file with interpolation
     computed globally by module
 
     Args:
         tableModel (QStandardItemModel): the table that displays the trajectory 
         fileName (String): the file name of the imported .gpx file
+        ref_time_used (Boolean): whether the first time point is used as reference
 
     Returns:
         Any: null
@@ -156,7 +97,7 @@ def import_gpx_file_module(tableModel: QStandardItemModel, fileName):
         gpx_read(fileName), 2)  #TODO resolution to be defined
     first_interp_point_time = GPXTrackPoint(
         gpx_datas['lat'][0], gpx_datas['lon'][0], gpx_datas['ele'][0], gpx_datas['tstamp'][0])
-    ref_tstamp = first_interp_point_time.time
+    ref_tstamp = first_interp_point_time.time if ref_time_used else 0.0
     previous_interp_point = first_interp_point_time
     previous_attitude = Attitude(0, 0, 0)
     for j in range(1, len(gpx_datas['lat'])):

--- a/src/main/python/importer/importer.py
+++ b/src/main/python/importer/importer.py
@@ -7,17 +7,26 @@ import math
 from gpxpy.gpx import GPXTrackPoint
 from src.main.python.importer.specific_parsers import SpecificParser
 from src.main.python.datas.datas_manager import FlightDatasManager
-from src.main.python.flight_model.flight_model import Attitude, compute_attitude_from_gpx
+from src.main.python.flight_model.flight_model import (
+    Attitude,
+    compute_attitude_from_gpx,
+)
 from src.main.python.tools.gpx_interpolate import GPXData, gpx_interpolate, gpx_read
 
-M_TO_FT = 1/0.3048
+M_TO_FT = 1 / 0.3048
 
 
-def import_gpx_file(tableModel: QStandardItemModel, fileName, limit=math.inf, with_supp_data=False, ref_time_used=False):
+def import_gpx_file(
+    tableModel: QStandardItemModel,
+    fileName,
+    limit=math.inf,
+    with_supp_data=False,
+    ref_time_used=False,
+):
     """Updates the table with the trajectory found in a given .gpx file
 
     Args:
-        tableModel (QStandardItemModel): the table that displays the trajectory 
+        tableModel (QStandardItemModel): the table that displays the trajectory
         fileName (String): the file name of the imported .gpx file
         limit (int): an optional limit of imported rows
         with_supp_data (bool): if supplementary data are retrieved from description tag
@@ -26,13 +35,13 @@ def import_gpx_file(tableModel: QStandardItemModel, fileName, limit=math.inf, wi
     Returns:
         Any: null
     """
-    with open(fileName, 'r') as gpxfile:
+    with open(fileName, "r") as gpxfile:
         reader_gpx = gpxpy.parse(gpxfile)
         headers = FlightDatasManager.get_current_keys()
         first_point = reader_gpx.tracks[0].segments[0].points[0]
-        
-        previous_point = first_point        
-        
+
+        previous_point = first_point
+
         if with_supp_data:
             spec_parser = SpecificParser(first_point.description)
             previous_specific = spec_parser.parse_data(first_point.description)
@@ -44,23 +53,30 @@ def import_gpx_file(tableModel: QStandardItemModel, fileName, limit=math.inf, wi
                         attitude = Attitude(0, 0, 0)
                         row = [
                             QStandardItem(
-                                str(previous_point.time_difference(first_point) if ref_time_used else previous_point.time.timestamp())),
+                                str(
+                                    previous_point.time_difference(first_point)
+                                    if ref_time_used
+                                    else previous_point.time.timestamp()
+                                )
+                            ),
                             QStandardItem(str(previous_point.latitude)),
                             QStandardItem(str(previous_point.longitude)),
                             QStandardItem(str(previous_point.elevation)),
                             QStandardItem(str(attitude.phi)),
                             QStandardItem(str(attitude.theta)),
-                            QStandardItem(str(attitude.psi))
+                            QStandardItem(str(attitude.psi)),
                         ]
-                        
+
                         if with_supp_data:
                             # Add and update specific values
                             for v in previous_specific.values():
                                 row.append(QStandardItem(str(v)))
-                            previous_specific = spec_parser.parse_data(point.description)
+                            previous_specific = spec_parser.parse_data(
+                                point.description
+                            )
 
                         tableModel.appendRow(row)
-                        
+
                     previous_point = point
                     if i >= limit:
                         break
@@ -72,52 +88,67 @@ def import_gpx_file(tableModel: QStandardItemModel, fileName, limit=math.inf, wi
             break
 
         for i, header in enumerate(headers):
-            tableModel.setHeaderData(
-                i, Qt.Orientation.Horizontal, header)
-            
+            tableModel.setHeaderData(i, Qt.Orientation.Horizontal, header)
+
         if with_supp_data:
             for i, header in enumerate(spec_parser.headers.keys()):
                 tableModel.setHeaderData(
-                    len(headers) + i, Qt.Orientation.Horizontal, header)
+                    len(headers) + i, Qt.Orientation.Horizontal, header
+                )
         # Set time label initial value
 
-def import_gpx_file_module(tableModel: QStandardItemModel, fileName, limit=math.inf, ref_time_used=False):
+
+def import_gpx_file_module(
+    tableModel: QStandardItemModel,
+    fileName,
+    limit=math.inf-1,
+    ref_time_used=False,
+    interp_length=2.0,
+):
     """Updates the table with the trajectory found in a given .gpx file with interpolation
     computed globally by module
 
     Args:
-        tableModel (QStandardItemModel): the table that displays the trajectory 
+        tableModel (QStandardItemModel): the table that displays the trajectory
         fileName (String): the file name of the imported .gpx file
         limit (int): an optional limit of imported rows
         ref_time_used (Boolean): whether the first time point is used as reference
+        interp_length (float): the interpolation length
 
     Returns:
         Any: null
     """
-    gpx_datas = gpx_interpolate(
-        gpx_read(fileName), 2)  #TODO resolution to be defined
+    gpx_datas = gpx_interpolate(gpx_read(fileName), interp_length)
     first_interp_point_time = GPXTrackPoint(
-        gpx_datas['lat'][0], gpx_datas['lon'][0], gpx_datas['ele'][0], gpx_datas['tstamp'][0])
+        gpx_datas["lat"][0],
+        gpx_datas["lon"][0],
+        gpx_datas["ele"][0],
+        gpx_datas["tstamp"][0],
+    )
     ref_tstamp = first_interp_point_time.time if ref_time_used else 0.0
     previous_interp_point = first_interp_point_time
     previous_attitude = Attitude(0, 0, 0)
-    for j in range(1, min(len(gpx_datas['lat']), limit)):
+    for j in range(1, min(len(gpx_datas["lat"]), limit+1)):
         interp_point = GPXTrackPoint(
-            gpx_datas['lat'][j], gpx_datas['lon'][j], gpx_datas['ele'][j], gpx_datas['tstamp'][j])
+            gpx_datas["lat"][j],
+            gpx_datas["lon"][j],
+            gpx_datas["ele"][j],
+            gpx_datas["tstamp"][j],
+        )
         attitude = compute_attitude_from_gpx(
-            previous_attitude, previous_interp_point, interp_point)
+            previous_attitude, previous_interp_point, interp_point
+        )
         row = [
-            QStandardItem(str(previous_interp_point.time-ref_tstamp)),
+            QStandardItem(str(previous_interp_point.time - ref_tstamp)),
             QStandardItem(str(previous_interp_point.latitude)),
             QStandardItem(str(previous_interp_point.longitude)),
-            QStandardItem(str(previous_interp_point.elevation*M_TO_FT)),
+            QStandardItem(str(previous_interp_point.elevation * M_TO_FT)),
             QStandardItem(str(attitude.phi if (j > 1) else 0)),
             QStandardItem(str(attitude.theta)),
-            QStandardItem(str(attitude.psi))
+            QStandardItem(str(attitude.psi)),
         ]
         tableModel.appendRow(row)
         previous_interp_point = interp_point
         previous_attitude = attitude
     for i, header in enumerate(FlightDatasManager.get_current_keys()):
-            tableModel.setHeaderData(
-                i, Qt.Orientation.Horizontal, header)
+        tableModel.setHeaderData(i, Qt.Orientation.Horizontal, header)

--- a/src/main/python/ui/import_window_ui.py
+++ b/src/main/python/ui/import_window_ui.py
@@ -348,6 +348,11 @@ class Ui_ImportWindow(object):
 
         self.verticalLayout_2.addWidget(self.dataEnhancementGroup)
 
+        self.previewLabel = QLabel(ImportWindow)
+        self.previewLabel.setObjectName(u"previewLabel")
+
+        self.verticalLayout_2.addWidget(self.previewLabel)
+
         self.tableView = QTableView(ImportWindow)
         self.tableView.setObjectName(u"tableView")
 
@@ -416,6 +421,7 @@ class Ui_ImportWindow(object):
         self.supplementaryParamscheckBox.setText(QCoreApplication.translate("ImportWindow", u"Supplementary Parameters", None))
         self.interpolationCheckBox.setText(QCoreApplication.translate("ImportWindow", u"Interpolation", None))
         self.setStartTimeAsOriginCheckBox.setText(QCoreApplication.translate("ImportWindow", u"Set Start Time As Origin", None))
+        self.previewLabel.setText(QCoreApplication.translate("ImportWindow", u"Preview", None))
         self.closeButton.setText(QCoreApplication.translate("ImportWindow", u"Close", None))
         self.importButton.setText(QCoreApplication.translate("ImportWindow", u"Import", None))
     # retranslateUi

--- a/src/main/python/ui/import_window_ui.py
+++ b/src/main/python/ui/import_window_ui.py
@@ -340,6 +340,11 @@ class Ui_ImportWindow(object):
 
         self.horizontalLayout_4.addWidget(self.interpolationCheckBox)
 
+        self.setStartTimeAsOriginCheckBox = QCheckBox(self.dataEnhancementGroup)
+        self.setStartTimeAsOriginCheckBox.setObjectName(u"setStartTimeAsOriginCheckBox")
+
+        self.horizontalLayout_4.addWidget(self.setStartTimeAsOriginCheckBox)
+
 
         self.verticalLayout_2.addWidget(self.dataEnhancementGroup)
 
@@ -410,6 +415,7 @@ class Ui_ImportWindow(object):
 #endif // QT_CONFIG(tooltip)
         self.supplementaryParamscheckBox.setText(QCoreApplication.translate("ImportWindow", u"Supplementary Parameters", None))
         self.interpolationCheckBox.setText(QCoreApplication.translate("ImportWindow", u"Interpolation", None))
+        self.setStartTimeAsOriginCheckBox.setText(QCoreApplication.translate("ImportWindow", u"Set Start Time As Origin", None))
         self.closeButton.setText(QCoreApplication.translate("ImportWindow", u"Close", None))
         self.importButton.setText(QCoreApplication.translate("ImportWindow", u"Import", None))
     # retranslateUi

--- a/src/main/python/ui/import_window_ui.py
+++ b/src/main/python/ui/import_window_ui.py
@@ -15,16 +15,17 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QFont, QFontDatabase, QGradient, QIcon,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
-from PySide6.QtWidgets import (QApplication, QCheckBox, QComboBox, QGroupBox,
-    QHBoxLayout, QHeaderView, QLabel, QLineEdit,
-    QPushButton, QRadioButton, QSizePolicy, QSpacerItem,
-    QSpinBox, QTableView, QVBoxLayout, QWidget)
+from PySide6.QtWidgets import (QApplication, QCheckBox, QComboBox, QDoubleSpinBox,
+    QGroupBox, QHBoxLayout, QHeaderView, QLabel,
+    QLineEdit, QPushButton, QRadioButton, QSizePolicy,
+    QSpacerItem, QSpinBox, QTableView, QVBoxLayout,
+    QWidget)
 
 class Ui_ImportWindow(object):
     def setupUi(self, ImportWindow):
         if not ImportWindow.objectName():
             ImportWindow.setObjectName(u"ImportWindow")
-        ImportWindow.resize(1051, 616)
+        ImportWindow.resize(1051, 617)
         self.verticalLayout_2 = QVBoxLayout(ImportWindow)
         self.verticalLayout_2.setObjectName(u"verticalLayout_2")
         self.fileGroup = QGroupBox(ImportWindow)
@@ -335,15 +336,41 @@ class Ui_ImportWindow(object):
 
         self.horizontalLayout_4.addWidget(self.supplementaryParamscheckBox)
 
-        self.interpolationCheckBox = QCheckBox(self.dataEnhancementGroup)
-        self.interpolationCheckBox.setObjectName(u"interpolationCheckBox")
-
-        self.horizontalLayout_4.addWidget(self.interpolationCheckBox)
-
         self.setStartTimeAsOriginCheckBox = QCheckBox(self.dataEnhancementGroup)
         self.setStartTimeAsOriginCheckBox.setObjectName(u"setStartTimeAsOriginCheckBox")
 
         self.horizontalLayout_4.addWidget(self.setStartTimeAsOriginCheckBox)
+
+        self.interpolationVerticalLayout = QVBoxLayout()
+        self.interpolationVerticalLayout.setObjectName(u"interpolationVerticalLayout")
+        self.interpolationCheckBox = QCheckBox(self.dataEnhancementGroup)
+        self.interpolationCheckBox.setObjectName(u"interpolationCheckBox")
+
+        self.interpolationVerticalLayout.addWidget(self.interpolationCheckBox)
+
+        self.interpolationHorizontalLayout = QHBoxLayout()
+        self.interpolationHorizontalLayout.setObjectName(u"interpolationHorizontalLayout")
+        self.interpLengthLabel = QLabel(self.dataEnhancementGroup)
+        self.interpLengthLabel.setObjectName(u"interpLengthLabel")
+
+        self.interpolationHorizontalLayout.addWidget(self.interpLengthLabel)
+
+        self.interpDoubleSpinBox = QDoubleSpinBox(self.dataEnhancementGroup)
+        self.interpDoubleSpinBox.setObjectName(u"interpDoubleSpinBox")
+        self.interpDoubleSpinBox.setAlignment(Qt.AlignmentFlag.AlignLeading|Qt.AlignmentFlag.AlignLeft|Qt.AlignmentFlag.AlignVCenter)
+        self.interpDoubleSpinBox.setDecimals(1)
+        self.interpDoubleSpinBox.setMinimum(0.100000000000000)
+        self.interpDoubleSpinBox.setMaximum(100.000000000000000)
+        self.interpDoubleSpinBox.setSingleStep(0.500000000000000)
+        self.interpDoubleSpinBox.setValue(2.000000000000000)
+
+        self.interpolationHorizontalLayout.addWidget(self.interpDoubleSpinBox)
+
+
+        self.interpolationVerticalLayout.addLayout(self.interpolationHorizontalLayout)
+
+
+        self.horizontalLayout_4.addLayout(self.interpolationVerticalLayout)
 
 
         self.verticalLayout_2.addWidget(self.dataEnhancementGroup)
@@ -419,8 +446,9 @@ class Ui_ImportWindow(object):
         self.supplementaryParamscheckBox.setToolTip("")
 #endif // QT_CONFIG(tooltip)
         self.supplementaryParamscheckBox.setText(QCoreApplication.translate("ImportWindow", u"Supplementary Parameters", None))
-        self.interpolationCheckBox.setText(QCoreApplication.translate("ImportWindow", u"Interpolation", None))
         self.setStartTimeAsOriginCheckBox.setText(QCoreApplication.translate("ImportWindow", u"Set Start Time As Origin", None))
+        self.interpolationCheckBox.setText(QCoreApplication.translate("ImportWindow", u"Interpolation", None))
+        self.interpLengthLabel.setText(QCoreApplication.translate("ImportWindow", u"Interpolation Length (m) :", None))
         self.previewLabel.setText(QCoreApplication.translate("ImportWindow", u"Preview", None))
         self.closeButton.setText(QCoreApplication.translate("ImportWindow", u"Close", None))
         self.importButton.setText(QCoreApplication.translate("ImportWindow", u"Import", None))

--- a/src/main/ui_models/importWindow.ui
+++ b/src/main/ui_models/importWindow.ui
@@ -543,6 +543,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="previewLabel">
+     <property name="text">
+      <string>Preview</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QTableView" name="tableView"/>
    </item>
    <item>

--- a/src/main/ui_models/importWindow.ui
+++ b/src/main/ui_models/importWindow.ui
@@ -532,6 +532,13 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QCheckBox" name="setStartTimeAsOriginCheckBox">
+        <property name="text">
+         <string>Set Start Time As Origin</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/main/ui_models/importWindow.ui
+++ b/src/main/ui_models/importWindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1051</width>
-    <height>616</height>
+    <height>617</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -526,18 +526,55 @@
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="interpolationCheckBox">
-        <property name="text">
-         <string>Interpolation</string>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="QCheckBox" name="setStartTimeAsOriginCheckBox">
         <property name="text">
          <string>Set Start Time As Origin</string>
         </property>
        </widget>
+      </item>
+      <item>
+       <layout class="QVBoxLayout" name="interpolationVerticalLayout">
+        <item>
+         <widget class="QCheckBox" name="interpolationCheckBox">
+          <property name="text">
+           <string>Interpolation</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="interpolationHorizontalLayout">
+          <item>
+           <widget class="QLabel" name="interpLengthLabel">
+            <property name="text">
+             <string>Interpolation Length (m) :</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QDoubleSpinBox" name="interpDoubleSpinBox">
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+            </property>
+            <property name="decimals">
+             <number>1</number>
+            </property>
+            <property name="minimum">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>100.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.500000000000000</double>
+            </property>
+            <property name="value">
+             <double>2.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
## Changes

- add checkbox to use relative/absolute origin time
- reorganize import window (ex: remove csv config fields in case a gpx file is opened)
- restructure interpolation linked fields for gpx files and link it with preview
- clean import methods

⚠️ **I removed a return type definition is *simconnect.py* as it makes my python interpretor fails for mainQt  run**